### PR TITLE
Support loading parameters from boardid.config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 
 VERSION=1.4.0
 
-boardid: $(wildcard src/*.c)
+SRCS = $(wildcard src/*.c)
+
+all: boardid
+
+boardid: $(SRCS)
 	$(CC) -Wall -O2 -DPROGRAM_VERSION=$(VERSION) -o $@ $^
 
 check: boardid
@@ -10,4 +14,4 @@ check: boardid
 clean:
 	-rm -fr boardid tests/work
 
-.PHONY: clean check
+.PHONY: all clean check

--- a/src/boardid.c
+++ b/src/boardid.c
@@ -145,8 +145,15 @@ int main(int argc, char *argv[])
     memset(options, 0, sizeof(options));
     int current_set = -1;
 
+    if (argc >= 3 && strcmp(argv[1], "-r") == 0)
+        root_prefix = argv[2];
+
+    int merged_argc;
+    char *merged_argv[MAX_ARGC];
+    merge_config(argc, argv, &merged_argc, merged_argv, MAX_ARGC);
+
     int opt;
-    while ((opt = getopt(argc, argv, "b:f:k:l:n:r:vu:?")) != -1) {
+    while ((opt = getopt(merged_argc, merged_argv, "b:f:k:l:n:r:vu:?")) != -1) {
         switch (opt) {
         case 'b':
             current_set++;
@@ -212,7 +219,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (optind < argc) {
+    if (optind < merged_argc) {
         // Support deprecated mode of passing the digit count via a positional argument
         default_digits = strtol(argv[optind], 0, 0);
         if (default_digits < 1)

--- a/src/cfgloader.c
+++ b/src/cfgloader.c
@@ -1,0 +1,129 @@
+/*
+   Copyright 2018 Frank Hunleth
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <ctype.h>
+#include <err.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "common.h"
+
+static int parse_config_line(char *line, char **argv, int max_args)
+{
+    int argc = 0;
+    char *c = line;
+    char *token = NULL;
+#define STATE_SPACE 0
+#define STATE_TOKEN 1
+#define STATE_QUOTED_TOKEN 2
+    int state = STATE_SPACE;
+    while (*c != '\0') {
+        switch (state) {
+        case STATE_SPACE:
+            if (*c == '#')
+                return argc;
+            else if (isspace(*c))
+                break;
+            else if (*c == '"') {
+                token = c + 1;
+                state = STATE_QUOTED_TOKEN;
+            } else {
+                token = c;
+                state = STATE_TOKEN;
+            }
+            break;
+        case STATE_TOKEN:
+            if (*c == '#' || isspace(*c)) {
+                *argv = strndup(token, c - token);
+                argv++;
+                argc++;
+                token = NULL;
+
+                if (*c == '#' || argc == max_args)
+                    return argc;
+
+                state = STATE_SPACE;
+            }
+            break;
+        case STATE_QUOTED_TOKEN:
+            if (*c == '"') {
+                *argv = strndup(token, c - token);
+                argv++;
+                argc++;
+                token = NULL;
+                state = STATE_SPACE;
+
+                if (argc == max_args)
+                    return argc;
+            }
+            break;
+        }
+        c++;
+    }
+
+    if (token) {
+        *argv = strndup(token, c - token);
+        argc++;
+    }
+
+    return argc;
+}
+
+// This is a very simple config file parser that extracts
+// commandline arguments from the specified file.
+static int load_config(const char *filename,
+                       char **argv,
+                       int max_args)
+{
+    FILE *fp = fopen_helper(filename, "r");
+    if (!fp)
+        return 0;
+
+    int argc = 0;
+    char line[128];
+    while (fgets(line, sizeof(line), fp) && argc < max_args) {
+        int new_args = parse_config_line(line, argv, max_args - argc);
+        argc += new_args;
+        argv += new_args;
+    }
+
+    fclose(fp);
+    return argc;
+}
+
+void merge_config(int argc, char *argv[], int *merged_argc, char **merged_argv, int max_args)
+{
+    // When merging, argv[0] is first, then the
+    // arguments from boardid.config and then any
+    // additional arguments from the commandline.
+    // This way, the commandline takes precedence.
+    *merged_argc = 1;
+    merged_argv[0] = argv[0];
+
+    *merged_argc += load_config("/etc/boardid.config",
+                                &merged_argv[1],
+                                max_args - argc);
+
+    if (*merged_argc + argc - 1 > max_args) {
+        warn("Too many arguments specified between the config file and commandline. Dropping some.");
+        argc = max_args - *merged_argc + 1;
+    }
+
+    memcpy(&merged_argv[*merged_argc], &argv[1], (argc - 1) * sizeof(char**));
+    *merged_argc += argc - 1;
+}
+
+

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,7 @@
 
 #define MAX_SERIALNUMBER_LEN  32
 #define MAX_STRATEGIES_TO_TRY 8
+#define MAX_ARGC 64
 
 #ifndef PROGRAM_VERSION
 #define PROGRAM_VERSION unknown
@@ -33,6 +34,7 @@
 
 FILE *fopen_helper(const char *filename, const char *mode);
 void bin_to_hex(const uint8_t *input, size_t len, char *output);
+void merge_config(int argc, char *argv[], int *merged_argc, char **merged_argv, int max_args);
 
 struct id_options
 {

--- a/tests/030_cfgfile
+++ b/tests/030_cfgfile
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+#
+# Test loading a config file
+#
+
+cat >$WORK/proc/cpuinfo <<EOF
+processor	: 0
+model name	: ARMv6-compatible processor rev 7 (v6l)
+BogoMIPS	: 2.00
+Features	: half thumb fastmult vfp edsp java tls
+CPU implementer	: 0x41
+CPU architecture: 7
+CPU variant	: 0x0
+CPU part	: 0xb76
+CPU revision	: 7
+
+Hardware	: BCM2708
+Revision	: 000e
+Serial		: 0000000019f2f468
+EOF
+
+cat >$WORK/etc/boardid.config <<EOF
+# This is a comment
+-b rpi
+
+# 4 digits
+-n 4
+EOF
+
+cat >$EXPECTED <<EOF
+f468
+EOF


### PR DESCRIPTION
This makes it possible to centralize where the board id search list is
stored. Programs can call `boardid` without arguments and get the right
ID.