### PR TITLE
Always sleep

### DIFF
--- a/src/nerves_key.c
+++ b/src/nerves_key.c
@@ -21,8 +21,11 @@ int nerves_key_id(const struct id_options *options, char *buffer, int len)
     // The Nerves Key's serial number is in the OTP memory
     uint8_t otp[32];
     if (atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, 0, 0, otp, 32) < 0 &&
-        atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, 0, 0, otp, 32) < 0)
+        atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, 0, 0, otp, 32) < 0) {
+        atecc508a_sleep(fd);
+        atecc508a_close(fd);
         return 0;
+    }
 
     atecc508a_sleep(fd);
     atecc508a_close(fd);


### PR DESCRIPTION
This fixes an issue where errors from boardid would propagate to other code since the device wasn't put back to sleep. The other projects were fixed to recover from this, but it feels better to not exercise that error condition if we don't have to. The second commit fixes boardid so that it recovers from other code leaving the atecc508a in a bad state. 

This was found in manufacturing provisioning of the chips where the check of the ATECC508A's boardid occurred close enough in time to the provisioning of the ATECC508A that the failure of the former affected the latter. Since the ATECC508A puts itself to sleep automatically, this wasn't detected when provisioning by hand.