### PR TITLE
Reverse the override order between config and args

### DIFF
--- a/src/cfgloader.c
+++ b/src/cfgloader.c
@@ -107,23 +107,21 @@ static int load_config(const char *filename,
 void merge_config(int argc, char *argv[], int *merged_argc, char **merged_argv, int max_args)
 {
     // When merging, argv[0] is first, then the
-    // arguments from boardid.config and then any
-    // additional arguments from the commandline.
+    // commandline arguments and then boardid.config
+    // arguments.
     // This way, the commandline takes precedence.
-    *merged_argc = 1;
-    merged_argv[0] = argv[0];
+
+    if (argc > max_args)
+        argc = max_args;
+    memcpy(&merged_argv[0], &argv[0], argc * sizeof(char**));
+    *merged_argc = argc;
 
     *merged_argc += load_config("/etc/boardid.config",
-                                &merged_argv[1],
+                                &merged_argv[argc],
                                 max_args - argc);
 
-    if (*merged_argc + argc - 1 > max_args) {
+    if (*merged_argc == max_args)
         warn("Too many arguments specified between the config file and commandline. Dropping some.");
-        argc = max_args - *merged_argc + 1;
-    }
-
-    memcpy(&merged_argv[*merged_argc], &argv[1], (argc - 1) * sizeof(char**));
-    *merged_argc += argc - 1;
 }
 
 

--- a/tests/031_cmdline_overrides_cfgfile
+++ b/tests/031_cmdline_overrides_cfgfile
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# Test loading a config file
+#
+
+cat >$WORK/proc/cpuinfo <<EOF
+processor	: 0
+model name	: ARMv6-compatible processor rev 7 (v6l)
+BogoMIPS	: 2.00
+Features	: half thumb fastmult vfp edsp java tls
+CPU implementer	: 0x41
+CPU architecture: 7
+CPU variant	: 0x0
+CPU part	: 0xb76
+CPU revision	: 7
+
+Hardware	: BCM2708
+Revision	: 000e
+Serial		: 0000000019f2f468
+EOF
+
+cat >$WORK/etc/boardid.config <<EOF
+# This is a comment
+-b rpi
+
+# 4 digits
+-n 4
+EOF
+
+CMDLINE="-b force -f 0123456789"
+
+cat >$EXPECTED <<EOF
+0123456789
+EOF


### PR DESCRIPTION
It turned out to be backwards of what was useful so you could never
override the config file. This fixes it.