### PR TITLE
Refactor serial number trimming; simplify calls

### DIFF
--- a/src/atecc508a_id.c
+++ b/src/atecc508a_id.c
@@ -3,21 +3,21 @@
 
 #include <string.h>
 
-int atecc508a_id(const struct id_options *options, char *buffer, int len)
+bool atecc508a_id(const struct boardid_options *options, char *buffer)
 {
     int fd = atecc508a_open(options->filename);
     if (fd < 0)
-        return 0;
+        return false;
 
     if (atecc508a_wakeup(fd) < 0) {
         atecc508a_close(fd);
-        return 0;
+        return false;
     }
 
     uint8_t serial_number[9];
     if (atecc508a_read_serial(fd, serial_number) < 0) {
         atecc508a_close(fd);
-        return 0;
+        return false;
     }
 
     atecc508a_sleep(fd);
@@ -28,13 +28,7 @@ int atecc508a_id(const struct id_options *options, char *buffer, int len)
     bin_to_hex(serial_number, sizeof(serial_number), serial_number_hex);
 
     // The ATECC508A has a 18 character serial number (9 bytes)
-    if (len > sizeof(serial_number_hex))
-        len = sizeof(serial_number_hex);
-    if (len < 1)
-        len = 1;
-
-    int digits = len - 1;
-    memcpy(buffer, serial_number_hex, digits);
-    buffer[digits] = 0;
-    return 1;
+    memcpy(buffer, serial_number_hex, sizeof(serial_number_hex));
+    buffer[sizeof(serial_number_hex)] = 0;
+    return true;
 }

--- a/src/beagleboneblack.c
+++ b/src/beagleboneblack.c
@@ -21,7 +21,7 @@
 
 // Read the serial number from the Beaglebone's EEPROM
 // See the SRM
-int beagleboneblack_id(const struct id_options *options, char *buffer, int len)
+bool beagleboneblack_id(const struct boardid_options *options, char *buffer)
 {
     // Try both the Linux 3.8 and 4.1 EEPROM locations
     FILE *fp = fopen_helper("/sys/bus/i2c/devices/0-0050/eeprom", "r");
@@ -34,7 +34,7 @@ int beagleboneblack_id(const struct id_options *options, char *buffer, int len)
     unsigned char data[28];
     if (fread(data, 1, sizeof(data), fp) != sizeof(data)) {
         fclose(fp);
-        return 0;
+        return false;
     }
 
     fclose(fp);
@@ -44,19 +44,12 @@ int beagleboneblack_id(const struct id_options *options, char *buffer, int len)
             data[1] != 0x55 ||
             data[2] != 0x33 ||
             data[3] != 0xee)
-        return 0;
+        return false;
 
 
     // The BBB has a 12 character serial number
-    if (len > 12 + 1)
-        len = 12 + 1;
-    if (len < 1)
-        len = 1;
-
-    // Return the least significant digits of the serial number
-    // if not returning all of them.
-    int digits = len - 1;
-    memcpy(buffer, &data[16 + (12 - digits)], digits);
+    const int digits = 12;
+    memcpy(buffer, &data[16], digits);
     buffer[digits] = 0;
-    return 1;
+    return true;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -17,6 +17,7 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 
@@ -36,27 +37,28 @@ FILE *fopen_helper(const char *filename, const char *mode);
 void bin_to_hex(const uint8_t *input, size_t len, char *output);
 void merge_config(int argc, char *argv[], int *merged_argc, char **merged_argv, int max_args);
 
-struct id_options
+struct boardid_options
 {
-    const char *name;
+    // Options for all ID queriers
     int digits; // how many digits of the serial number to return
 
+    // Options that depend on the querier
     const char *filename;
     int offset;
     int size;
     const char *uenv_varname;
 };
 
-int cpuinfo_id(const struct id_options *options, char *buffer, int len);
-int macaddr_id(const struct id_options *options, char *buffer, int len);
-int beagleboneblack_id(const struct id_options *options, char *buffer, int len);
-int linkit_id(const struct id_options *options, char *buffer, int len);
-int binfile_id(const struct id_options *options, char *buffer, int len);
-int uboot_env_id(const struct id_options *options, char *buffer, int len);
-int atecc508a_id(const struct id_options *options, char *buffer, int len);
-int nerves_key_id(const struct id_options *options, char *buffer, int len);
-int dmi_id(const struct id_options *options, char *buffer, int len);
-int force_id(const struct id_options *options, char *buffer, int len);
+bool cpuinfo_id(const struct boardid_options *options, char *buffer);
+bool macaddr_id(const struct boardid_options *options, char *buffer);
+bool beagleboneblack_id(const struct boardid_options *options, char *buffer);
+bool linkit_id(const struct boardid_options *options, char *buffer);
+bool binfile_id(const struct boardid_options *options, char *buffer);
+bool uboot_env_id(const struct boardid_options *options, char *buffer);
+bool atecc508a_id(const struct boardid_options *options, char *buffer);
+bool nerves_key_id(const struct boardid_options *options, char *buffer);
+bool dmi_id(const struct boardid_options *options, char *buffer);
+bool force_id(const struct boardid_options *options, char *buffer);
 
 // The root prefix is used for unit testing so that simulated /proc or /sys
 // files can be used.

--- a/src/cpuinfo.c
+++ b/src/cpuinfo.c
@@ -23,11 +23,11 @@
 // Read the serial number from /proc/cpuinfo.
 // The Raspberry Pi and Lego EV3 report their serial number using this mechanism.
 
-int cpuinfo_id(const struct id_options *options, char *buffer, int len)
+bool cpuinfo_id(const struct boardid_options *options, char *buffer)
 {
     FILE *fp = fopen_helper("/proc/cpuinfo", "r");
     if (!fp)
-        return 0;
+        return false;
 
     char line[256];
     const char *serial = NULL;
@@ -42,17 +42,15 @@ int cpuinfo_id(const struct id_options *options, char *buffer, int len)
 
     // Make sure that the serial number was found.
     if (!serial)
-        return 0;
+        return false;
 
-    // The user may specify how many digits to print
-    int max_digits = strlen(serial) - 1; // -1 is for the '\n' at the end of the line
-    int digits = len - 1;
-    if (digits > max_digits)
-        digits = max_digits;
+    // Copy the serial number to the output buffer
+    int digits = strlen(serial) - 1; // -1 is for the '\n' at the end of the line
+    if (digits > MAX_SERIALNUMBER_LEN)
+        digits = MAX_SERIALNUMBER_LEN;
 
-    int offset = max_digits - digits;
-    memcpy(buffer, serial + offset, digits);
+    memcpy(buffer, serial, digits);
     buffer[digits] = '\0';
 
-    return 1;
+    return true;
 }

--- a/src/dmi.c
+++ b/src/dmi.c
@@ -131,11 +131,11 @@ static int scan_smbios_structures(const uint8_t *data, int len, struct dmi_info 
 }
 
 
-int dmi_id(const struct id_options *options, char *buffer, int len)
+bool dmi_id(const struct boardid_options *options, char *buffer)
 {
     FILE *fp = fopen_helper("/sys/firmware/dmi/tables/DMI", "r");
     if (!fp)
-        return 0;
+        return false;
 
     uint8_t data[4096];
     size_t amount_read = fread(data, 1, sizeof(data), fp);
@@ -144,17 +144,14 @@ int dmi_id(const struct id_options *options, char *buffer, int len)
     // See if we can find the serial number in the DMI info
     struct dmi_info result;
     if (!scan_smbios_structures(data, amount_read, &result))
-        return 0;
+        return false;
 
-    // The user may specify how many digits to print
-    int max_digits = strlen(result.serial);
-    int digits = len - 1;
-    if (digits > max_digits)
-        digits = max_digits;
+    int digits = strlen(result.serial);
+    if (digits > MAX_SERIALNUMBER_LEN)
+        digits = MAX_SERIALNUMBER_LEN;
 
-    int offset = max_digits - digits;
-    memcpy(buffer, result.serial + offset, digits);
+    memcpy(buffer, result.serial, digits);
     buffer[digits] = '\0';
 
-    return 1;
+    return true;
 }

--- a/src/force.c
+++ b/src/force.c
@@ -19,18 +19,15 @@
 #include <err.h>
 #include <string.h>
 
-int force_id(const struct id_options *options, char *buffer, int len)
+bool force_id(const struct boardid_options *options, char *buffer)
 {
     if (!options->filename) {
         warnx("specify -f to force an ID");
-        return 0;
+        return false;
     }
 
-    strncpy(buffer, options->filename, len - 1);
-    buffer[len - 1] = '\0';
+    strncpy(buffer, options->filename, MAX_SERIALNUMBER_LEN);
+    buffer[MAX_SERIALNUMBER_LEN] = '\0';
 
-    if (buffer[0] == '\0')
-        return 0;
-    else
-        return 1;
+    return buffer[0] != '\0';
 }

--- a/src/macaddr.c
+++ b/src/macaddr.c
@@ -25,11 +25,11 @@ static void remove_char(char *str, char c);
 // Read the MAC Address from /sys/class/net/eth0/address and use
 // it as a unique ID after removing the colons..
 
-int macaddr_id(const struct id_options *options, char *buffer, int len)
+bool macaddr_id(const struct boardid_options *options, char *buffer)
 {
     FILE *fp = fopen_helper("/sys/class/net/eth0/address", "r");
     if (!fp)
-        return 0;
+        return false;
 
     char line[256];
     char *rc = fgets(line, sizeof(line), fp);
@@ -39,7 +39,7 @@ int macaddr_id(const struct id_options *options, char *buffer, int len)
     // with each byte separated with a colon. That is, 12 hex
     // characters and 5 colons, so 17 characters.
     if (!rc || strlen(line) < 17)
-       return 0;
+       return false;
 
     // Remove the colons
     remove_char(line, ':');
@@ -47,18 +47,9 @@ int macaddr_id(const struct id_options *options, char *buffer, int len)
     // Trim any trailing whitespace
     line[12] = '\0';
 
-    // The user may specify how many digits to print
-    // If so, return the least significant ones.
-    int max_digits = 12;
-    int digits = len - 1;
-    if (digits > max_digits)
-        digits = max_digits;
+    strcpy(buffer, line);
 
-    int offset = max_digits - digits;
-    memcpy(buffer, line + offset, digits);
-    buffer[digits] = '\0';
-
-    return 1;
+    return true;
 }
 
 void remove_char(char *str, char c)


### PR DESCRIPTION
This centralizes the serial number trimming code so that it's in one
place rather than in each serial number reader. It also simplifies the
API so that it will be possible to separate the implementation from the
commandline application.