### PR TITLE
Support reading the ID from the device tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported boards:
 * [LinkIt Smart 7688](https://www.seeedstudio.com/LinkIt-Smart-7688-p-2573.html)
 * Next Thing Co - C.H.I.P.
 * Many off-the-shelf industrial x86 boards via SMBIOS/DMI
+* nVidia Jetson
 
 If your board isn't listed above, it may be supported via one of the generic
 mechanisms:
@@ -25,6 +26,7 @@ mechanisms:
 * Reading an [ATECC508A/608A](https://www.microchip.com/wwwproducts/en/ATECC508A)'s serial number via an I2C bus
 * Reading the serial number stored in a [NervesKey](https://github.com/nerves-hub/nerves_key/)'s OTP memory
 * Reading the serial number from [SMBIOS/DMI](https://www.dmtf.org/standards/smbios)
+* Reading the serial number via the device tree
 
 If your board isn't supported, please consider sending a pull request.
 
@@ -56,17 +58,17 @@ Supported boards/methods:
   ev3        Lego EV3
   chip       Next Thing Co - C.H.I.P.
   cpuinfo    Read /proc/cpuinfo
-  dmi        Read the system ID out of the SMBIOS/DMI (x86 devices)
+  jetson     nVidia Jetson
+  device_tree  Read /proc/device-tree/serial-number
   bbb        Beaglebone Black
   macaddr    Read eth0's MAC address
   linkit     LinkIt Smart (WLAN MAC address)
   binfile    Read '-l' bytes from the file '-f' at offset '-k'
-  uboot_env  Read a U-Boot environment (use `/etc/fw_env.config` or specify
-             file '-f', offset '-k', length '-l') and use the variable '-u'
+  uboot_env  Read a U-Boot environment (file '-f', offset '-k', length '-l') and use the variable '-u'
   atecc508a  Read an ATECC508A (I2C device '-f')
-  nerves_key Read a NervesKey serial number (I2C device '-f')
-  force      Force an ID (specify the ID with '-f')
-```
+  nerves_key  Read a NervesKey (I2C device '-f')
+  dmi        Read the system ID out of the SMBIOS/DMI
+  force      Force the ID (Specify ID with '-f')
 
 Without the `-b` option, `boardid` will try a few methods of determining an ID.
 

--- a/src/boardid.c
+++ b/src/boardid.c
@@ -43,6 +43,12 @@ static const char *cpuinfo_aliases[] = {
     NULL,       NULL
 };
 
+static const char *device_tree_aliases[] = {
+    "jetson",   "nVidia Jetson",
+    "device_tree",  "Read /proc/device-tree/serial-number",
+    NULL,       NULL
+};
+
 static const char *bbb_aliases[] = {
     "bbb",      "Beaglebone Black",
     NULL,       NULL
@@ -90,6 +96,7 @@ static const char *force_aliases[] = {
 
 static const struct board_id_pair boards[] = {
     { cpuinfo_aliases, cpuinfo_id, true, false },
+    { device_tree_aliases, device_tree_id, true, false },
     { bbb_aliases, beagleboneblack_id, true, false },
     { macaddr_aliases, macaddr_id, true, false },
     { linkit_aliases, linkit_id, true, false },

--- a/src/common.h
+++ b/src/common.h
@@ -50,6 +50,7 @@ struct boardid_options
 };
 
 bool cpuinfo_id(const struct boardid_options *options, char *buffer);
+bool device_tree_id(const struct boardid_options *options, char *buffer);
 bool macaddr_id(const struct boardid_options *options, char *buffer);
 bool beagleboneblack_id(const struct boardid_options *options, char *buffer);
 bool linkit_id(const struct boardid_options *options, char *buffer);

--- a/src/device_tree.c
+++ b/src/device_tree.c
@@ -1,0 +1,47 @@
+/*
+   Copyright 2020 Nerves Project Developers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "common.h"
+
+// Read the serial number from /proc/device-tree/serial-number.
+// The nVIDIA Jetson Nano and probably quite a few other devices
+// report their IDs through here.
+
+bool device_tree_id(const struct boardid_options *options, char *buffer)
+{
+    FILE *fp = fopen_helper("/proc/device-tree/serial-number", "r");
+    if (!fp)
+        return false;
+
+    size_t len = fread(buffer, 1, MAX_SERIALNUMBER_LEN, fp);
+    fclose(fp);
+
+    // Strip any newlines off the end.
+    for (size_t i = 0; i < len; i++) {
+        if (buffer[i] == '\n') {
+            len = i;
+            break;
+        }
+    }
+    buffer[len] = '\0';
+
+    // Make sure that the serial number was found.
+    return len > 0;
+}

--- a/tests/037_device_tree
+++ b/tests/037_device_tree
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#
+# Read ID from /proc/device-tree/serial-number
+#
+
+mkdir -p "$WORK/proc/device-tree"
+cat >"$WORK/proc/device-tree/serial-number" << EOF
+0421519091609
+EOF
+
+CMDLINE="-b device_tree"
+
+cat >"$EXPECTED" <<EOF
+0421519091609
+EOF

--- a/tests/038_device_tree_auto
+++ b/tests/038_device_tree_auto
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#
+# Check that the device-tree is an automatically checked location
+#
+
+mkdir -p "$WORK/proc/device-tree"
+cat >"$WORK/proc/device-tree/serial-number" << EOF
+0421519091609
+EOF
+
+CMDLINE=""
+
+cat >"$EXPECTED" <<EOF
+0421519091609
+EOF


### PR DESCRIPTION
This is needed to retrieve IDs on nVidia Jetsons and almost certainly
other boards.