### PR TITLE
osx and STM32MP1

### DIFF
--- a/src/atecc508a.c
+++ b/src/atecc508a.c
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 
+#ifndef __APPLE__
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
@@ -442,3 +443,18 @@ cleanup:
     atecc508a_sleep(fd);
     return rc;
 }
+#else
+
+#include "atecc508a.h"
+
+// Return errors on OSX
+int atecc508a_open(const char *filename) { return -1; }
+void atecc508a_close(int fd) {}
+int atecc508a_wakeup(int fd) { return -1; }
+int atecc508a_sleep(int fd) { return -1; }
+int atecc508a_read_serial(int fd, uint8_t *serial_number) { return -1; }
+int atecc508a_derive_public_key(int fd, uint8_t slot, uint8_t *key) { return -1; }
+int atecc508a_sign(int fd, uint8_t slot, const uint8_t *data, uint8_t *signature) { return -1; }
+int atecc508a_read_zone_nowake(int fd, uint8_t zone, uint16_t slot, uint8_t block, uint8_t offset, uint8_t *data, uint8_t len) { return -1; }
+
+#endif

--- a/tests/036_stm32mp1_all
+++ b/tests/036_stm32mp1_all
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+#
+# Verify that STM32MP1 serial numbers work. They're 24 hex digits long
+# which makes them longer than most other devices.
+#
+
+cat >$WORK/proc/cpuinfo <<EOF
+processor	: 0
+model name	: ARMv7 Processor rev 5 (v7l)
+BogoMIPS	: 48.00
+Features	: half thumb fastmult vfp edsp thumbee neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer	: 0x41
+CPU architecture: 7
+CPU variant	: 0x0
+CPU part	: 0xc07
+CPU revision	: 5
+
+processor	: 1
+model name	: ARMv7 Processor rev 5 (v7l)
+BogoMIPS	: 48.00
+Features	: half thumb fastmult vfp edsp thumbee neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm
+CPU implementer	: 0x41
+CPU architecture: 7
+CPU variant	: 0x0
+CPU part	: 0xc07
+CPU revision	: 5
+
+Hardware	: STM32 (Device Tree Support)
+Revision	: 0000
+Serial		: 0032001C3338510934383330
+EOF
+
+CMDLINE="-b cpuinfo"
+
+cat >$EXPECTED <<EOF
+0032001C3338510934383330
+EOF


### PR DESCRIPTION
This adds a test so that we don't accidentally break the STM32MP1's really long IDs. It turns out that we have room to spare, but I wasn't sure when I first saw the ID.