### PR TITLE
nerves_key: add long serial number support

### DIFF
--- a/src/nerves_key.c
+++ b/src/nerves_key.c
@@ -23,6 +23,15 @@
 
 static uint8_t nerves_key_magic[4] = {0x4e, 0x72, 0x76, 0x73};
 
+static int retry_read_otp(int fd, int block, uint8_t *dest)
+{
+    if (atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, block, 0, dest, 32) < 0
+        && atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, block, 0, dest, 32) < 0)
+        return -1;
+    else
+        return 0;
+}
+
 bool nerves_key_id(const struct boardid_options *options, char *buffer)
 {
     int fd = atecc508a_open(options->filename);
@@ -35,24 +44,26 @@ bool nerves_key_id(const struct boardid_options *options, char *buffer)
     }
 
     // The Nerves Key's serial number is in the OTP memory
-    uint8_t otp[32];
-    if (atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, 0, 0, otp, 32) < 0 &&
-        atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, 0, 0, otp, 32) < 0) {
-        atecc508a_sleep(fd);
-        atecc508a_close(fd);
-        return false;
-    }
+    uint8_t otp[64];
+    memset(otp, 0, sizeof(otp));
 
+    bool rc = false;
+    if (retry_read_otp(fd, 0, otp) == 0) {
+        int flags = (otp[4] << 8) + otp[5];
+        size_t max_len = (flags & 1) ? 48 : 16;
+
+        if (memcmp(otp, nerves_key_magic, sizeof(nerves_key_magic)) == 0
+            && (max_len == 16 || retry_read_otp(fd, 1, &otp[32]) == 0)) {
+
+            const char *serial_number = (const char *) &otp[16];
+            size_t serial_number_len = strnlen(serial_number, max_len);
+
+            memcpy(buffer, serial_number, serial_number_len);
+            buffer[serial_number_len] = 0;
+            rc = true;
+        }
+    }
     atecc508a_sleep(fd);
     atecc508a_close(fd);
-
-    if (memcmp(otp, nerves_key_magic, sizeof(nerves_key_magic)) != 0)
-        return false;
-
-    const char *serial_number = (const char *) &otp[16];
-    size_t serial_number_len = strnlen(serial_number, 16);
-
-    memcpy(buffer, serial_number, serial_number_len);
-    buffer[serial_number_len] = 0;
-    return true;
+    return rc;
 }


### PR DESCRIPTION
This adds long serial number support based on the OTP data's flags
setting. The code has been written so that if the flag has not been set,
`boardid` only makes one read request to the ATECC. If the flag is set,
then two reads are made so that the remainder of the serial number can
be read. This was done in an abundance of caution to avoid changing any
I2C bus traffic on production devices.