### PR TITLE
Support a non-default I2C address for atecc508a/nerves_key methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options:
   -u <varname>      U-boot environment variable name for the 'uenv' method
   -n <count>        Print out count characters (least significant ones)
   -p <string>       Prefix an ID with the specific string
+  -a <i2c address>  I2C address for the `atecc508a`/`nerves_key` methods
   -r <prefix>       Root directory prefix (used for unit tests)
   -v                Print out the program version
 
@@ -65,8 +66,8 @@ Supported boards/methods:
   linkit     LinkIt Smart (WLAN MAC address)
   binfile    Read '-l' bytes from the file '-f' at offset '-k'
   uboot_env  Read a U-Boot environment (file '-f', offset '-k', length '-l') and use the variable '-u'
-  atecc508a  Read an ATECC508A (I2C device '-f')
-  nerves_key  Read a NervesKey (I2C device '-f')
+  atecc508a  Read an ATECC508A (I2C device '-f', I2C address '-a')
+  nerves_key  Read a NervesKey (I2C device '-f', I2C address '-a')
   dmi        Read the system ID out of the SMBIOS/DMI
   force      Force the ID (Specify ID with '-f')
 

--- a/src/atecc508a.h
+++ b/src/atecc508a.h
@@ -19,17 +19,24 @@
 
 #include <stdint.h>
 
+#define ATECC508A_DEFAULT_ADDR 0x60
+
 #define ATECC508A_ZONE_CONFIG 0
 #define ATECC508A_ZONE_OTP    1
 #define ATECC508A_ZONE_DATA   2
 
-int atecc508a_open(const char *filename);
-void atecc508a_close(int fd);
-int atecc508a_wakeup(int fd);
-int atecc508a_sleep(int fd);
-int atecc508a_read_serial(int fd, uint8_t *serial_number);
-int atecc508a_derive_public_key(int fd, uint8_t slot, uint8_t *key);
-int atecc508a_sign(int fd, uint8_t slot, const uint8_t *data, uint8_t *signature);
-int atecc508a_read_zone_nowake(int fd, uint8_t zone, uint16_t slot, uint8_t block, uint8_t offset, uint8_t *data, uint8_t len);
+struct atecc508a_session {
+    int fd;
+    uint8_t addr;
+};
+
+int atecc508a_open(const char *filename, uint8_t i2c_address, struct atecc508a_session *session);
+void atecc508a_close(struct atecc508a_session *session);
+int atecc508a_wakeup(const struct atecc508a_session *session);
+int atecc508a_sleep(const struct atecc508a_session *session);
+int atecc508a_read_serial(const struct atecc508a_session *session, uint8_t *serial_number);
+int atecc508a_derive_public_key(const struct atecc508a_session *session, uint8_t slot, uint8_t *key);
+int atecc508a_sign(const struct atecc508a_session *session, uint8_t slot, const uint8_t *data, uint8_t *signature);
+int atecc508a_read_zone_nowake(const struct atecc508a_session *session, uint8_t zone, uint16_t slot, uint8_t block, uint8_t offset, uint8_t *data, uint8_t len);
 
 #endif // ATECC508A_H

--- a/src/atecc508a_id.c
+++ b/src/atecc508a_id.c
@@ -21,24 +21,28 @@
 
 bool atecc508a_id(const struct boardid_options *options, char *buffer)
 {
-    int fd = atecc508a_open(options->filename);
-    if (fd < 0)
+    uint8_t i2c_address = ATECC508A_DEFAULT_ADDR;
+    if (options->i2c_address > 0 && options->i2c_address < 128)
+        i2c_address = (uint8_t) options->i2c_address;
+
+    struct atecc508a_session atecc;
+    if (atecc508a_open(options->filename, i2c_address, &atecc) < 0)
         return false;
 
-    if (atecc508a_wakeup(fd) < 0) {
-        atecc508a_close(fd);
+    if (atecc508a_wakeup(&atecc) < 0) {
+        atecc508a_close(&atecc);
         return false;
     }
 
     uint8_t serial_number[9];
-    if (atecc508a_read_serial(fd, serial_number) < 0) {
-        atecc508a_close(fd);
+    if (atecc508a_read_serial(&atecc, serial_number) < 0) {
+        atecc508a_close(&atecc);
         return false;
     }
 
-    atecc508a_sleep(fd);
+    atecc508a_sleep(&atecc);
 
-    atecc508a_close(fd);
+    atecc508a_close(&atecc);
 
     char serial_number_hex[sizeof(serial_number) * 2 + 1];
     bin_to_hex(serial_number, sizeof(serial_number), serial_number_hex);

--- a/src/boardid.c
+++ b/src/boardid.c
@@ -75,12 +75,12 @@ static const char *uboot_env_aliases[] = {
 };
 
 static const char *atecc508a_aliases[] = {
-    "atecc508a",  "Read an ATECC508A (I2C device '-f')",
+    "atecc508a",  "Read an ATECC508A (I2C device '-f', I2C address '-a')",
     NULL,       NULL
 };
 
 static const char *nerves_key_aliases[] = {
-    "nerves_key",  "Read a NervesKey (I2C device '-f')",
+    "nerves_key",  "Read a NervesKey (I2C device '-f', I2C address '-a')",
     NULL,       NULL
 };
 
@@ -118,13 +118,14 @@ static void usage()
     printf("Options:\n");
     printf("  -b <board/method> Use the specified board or detection method for\n");
     printf("                    reading the ID.\n");
-    printf("  -f <path>         The file to read for the 'binfile'/'uenv' methods\n");
+    printf("  -f <path>         The file to read for the methods requiring files\n");
     printf("  -k <offset>       The offset in bytes for the 'binfile'/`uenv' methods\n");
     printf("  -l <count>        The number of bytes to read for the 'binfile'/'uenv' methods\n");
     printf("  -u <varname>      U-boot environment variable name for the 'uenv' method\n");
     printf("  -n <count>        Print out count characters (least significant ones)\n");
     printf("  -p <string>       Prefix an ID with the specific string\n");
     printf("  -r <prefix>       Root directory prefix (used for unit tests)\n");
+    printf("  -a <i2c address>  I2C bus address\n");
     printf("  -v                Print out the program version\n");
     printf("\n");
     printf("'-b' can be specified multiple times to try more than one method.\n");
@@ -261,7 +262,7 @@ int main(int argc, char *argv[])
     merge_config(argc, argv, &merged_argc, merged_argv, MAX_ARGC);
 
     int opt;
-    while ((opt = getopt(merged_argc, merged_argv, "b:f:k:l:n:p:r:vu:?")) != -1) {
+    while ((opt = getopt(merged_argc, merged_argv, "a:b:f:k:l:n:p:r:vu:?")) != -1) {
         switch (opt) {
         case 'b':
             current_set++;
@@ -314,6 +315,12 @@ int main(int argc, char *argv[])
 
         case 'r':
             root_prefix = optarg;
+            break;
+
+        case 'a':
+            if (current_set < 0)
+                errx(EXIT_FAILURE, "Specify '-b' first");
+            options[current_set].id_options.i2c_address = strtol(optarg, 0, 0);
             break;
 
         case 'v':

--- a/src/common.h
+++ b/src/common.h
@@ -47,6 +47,7 @@ struct boardid_options
     int offset;
     int size;
     const char *uenv_varname;
+    int i2c_address;
 };
 
 bool cpuinfo_id(const struct boardid_options *options, char *buffer);

--- a/src/nerves_key.c
+++ b/src/nerves_key.c
@@ -23,10 +23,10 @@
 
 static uint8_t nerves_key_magic[4] = {0x4e, 0x72, 0x76, 0x73};
 
-static int retry_read_otp(int fd, int block, uint8_t *dest)
+static int retry_read_otp(const struct atecc508a_session *session, int block, uint8_t *dest)
 {
-    if (atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, block, 0, dest, 32) < 0
-        && atecc508a_read_zone_nowake(fd, ATECC508A_ZONE_OTP, 0, block, 0, dest, 32) < 0)
+    if (atecc508a_read_zone_nowake(session, ATECC508A_ZONE_OTP, 0, block, 0, dest, 32) < 0
+        && atecc508a_read_zone_nowake(session, ATECC508A_ZONE_OTP, 0, block, 0, dest, 32) < 0)
         return -1;
     else
         return 0;
@@ -34,12 +34,16 @@ static int retry_read_otp(int fd, int block, uint8_t *dest)
 
 bool nerves_key_id(const struct boardid_options *options, char *buffer)
 {
-    int fd = atecc508a_open(options->filename);
-    if (fd < 0)
-        return 0;
+    uint8_t i2c_address = ATECC508A_DEFAULT_ADDR;
+    if (options->i2c_address > 0 && options->i2c_address < 128)
+        i2c_address = (uint8_t) options->i2c_address;
 
-    if (atecc508a_wakeup(fd) < 0) {
-        atecc508a_close(fd);
+    struct atecc508a_session atecc;
+    if (atecc508a_open(options->filename, i2c_address, &atecc) < 0)
+        return false;
+
+    if (atecc508a_wakeup(&atecc) < 0) {
+        atecc508a_close(&atecc);
         return false;
     }
 
@@ -48,12 +52,12 @@ bool nerves_key_id(const struct boardid_options *options, char *buffer)
     memset(otp, 0, sizeof(otp));
 
     bool rc = false;
-    if (retry_read_otp(fd, 0, otp) == 0) {
+    if (retry_read_otp(&atecc, 0, otp) == 0) {
         int flags = (otp[4] << 8) + otp[5];
         size_t max_len = (flags & 1) ? 48 : 16;
 
         if (memcmp(otp, nerves_key_magic, sizeof(nerves_key_magic)) == 0
-            && (max_len == 16 || retry_read_otp(fd, 1, &otp[32]) == 0)) {
+            && (max_len == 16 || retry_read_otp(&atecc, 1, &otp[32]) == 0)) {
 
             const char *serial_number = (const char *) &otp[16];
             size_t serial_number_len = strnlen(serial_number, max_len);
@@ -63,7 +67,7 @@ bool nerves_key_id(const struct boardid_options *options, char *buffer)
             rc = true;
         }
     }
-    atecc508a_sleep(fd);
-    atecc508a_close(fd);
+    atecc508a_sleep(&atecc);
+    atecc508a_close(&atecc);
     return rc;
 }


### PR DESCRIPTION
It's possible to reprogram the I2C address on the ATECC* parts. This adds
support to boardid for people who do that.