### PR TITLE
Add -X option to print capital hex digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
   -p <string>       Prefix an ID with the specific string
   -a <i2c address>  I2C address for the `atecc508a`/`nerves_key` methods
   -r <prefix>       Root directory prefix (used for unit tests)
+  -X                Print capital hex digits for `binfile`/`atecc508a` methods
   -v                Print out the program version
 
 '-b' can be specified multiple times to try more than one method.

--- a/src/atecc508a_id.c
+++ b/src/atecc508a_id.c
@@ -45,7 +45,7 @@ bool atecc508a_id(const struct boardid_options *options, char *buffer)
     atecc508a_close(&atecc);
 
     char serial_number_hex[sizeof(serial_number) * 2 + 1];
-    bin_to_hex(serial_number, sizeof(serial_number), serial_number_hex);
+    bin_to_hex(serial_number, sizeof(serial_number), options->capital_hex, serial_number_hex);
 
     // The ATECC508A has a 18 character serial number (9 bytes)
     memcpy(buffer, serial_number_hex, sizeof(serial_number_hex));

--- a/src/binfile.c
+++ b/src/binfile.c
@@ -44,7 +44,7 @@ bool binfile_id(const struct boardid_options *options, char *buffer)
 
     fclose(fp);
 
-    bin_to_hex(data, idlen, buffer);
+    bin_to_hex(data, idlen, options->capital_hex, buffer);
     buffer[idlen * 2] = '\0';
 
     return true;

--- a/src/boardid.c
+++ b/src/boardid.c
@@ -145,6 +145,7 @@ static void usage()
     printf("  -p <string>       Prefix an ID with the specific string\n");
     printf("  -r <prefix>       Root directory prefix (used for unit tests)\n");
     printf("  -a <i2c address>  I2C bus address\n");
+    printf("  -X                Print capital hex digits for `binfile`/`atecc508a` methods");
     printf("  -v                Print out the program version\n");
     printf("\n");
     printf("'-b' can be specified multiple times to try more than one method.\n");
@@ -283,7 +284,7 @@ int main(int argc, char *argv[])
     merge_config(argc, argv, &merged_argc, merged_argv, MAX_ARGC);
 
     int opt;
-    while ((opt = getopt(merged_argc, merged_argv, "a:b:f:k:l:n:p:r:vu:?")) != -1) {
+    while ((opt = getopt(merged_argc, merged_argv, "a:b:f:k:l:n:p:r:vu:X?")) != -1) {
         switch (opt) {
         case 'b':
             current_set++;
@@ -352,6 +353,12 @@ int main(int argc, char *argv[])
             if (current_set < 0)
                 errx(EXIT_FAILURE, "Specify '-b' first");
             options[current_set].id_options.uenv_varname = optarg;
+            break;
+
+        case 'X':
+            if (current_set < 0)
+                errx(EXIT_FAILURE, "Specify '-b' first");
+            options[current_set].id_options.capital_hex = 1;
             break;
 
         case '?':

--- a/src/common.h
+++ b/src/common.h
@@ -34,7 +34,7 @@
 #define PROGRAM_VERSION_STR xstr(PROGRAM_VERSION)
 
 FILE *fopen_helper(const char *filename, const char *mode);
-void bin_to_hex(const uint8_t *input, size_t len, char *output);
+void bin_to_hex(const uint8_t *input, size_t len, int capital_hex, char *output);
 void merge_config(int argc, char *argv[], int *merged_argc, char **merged_argv, int max_args);
 
 struct boardid_options
@@ -47,6 +47,7 @@ struct boardid_options
     int offset;
     int size;
     const char *uenv_varname;
+    int capital_hex;
     int i2c_address;
 };
 

--- a/src/util.c
+++ b/src/util.c
@@ -37,9 +37,10 @@ FILE *fopen_helper(const char *filename, const char *mode)
     }
 }
 
-void bin_to_hex(const uint8_t *input, size_t len, char *output)
+void bin_to_hex(const uint8_t *input, size_t len, int capital_hex, char *output)
 {
+    const char *format = capital_hex ? "%02X" : "%02x";
     for (size_t i = 0; i < len; i++)
-        sprintf(&output[i * 2], "%02x", input[i]);
+        sprintf(&output[i * 2], format, input[i]);
 }
 

--- a/tests/045_binfile_caps
+++ b/tests/045_binfile_caps
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#
+# Read ID from a binary file w/ all digits, but print capital hex digits
+#
+
+xxd -r - $WORK/dev/mtdblock2 <<EOF
+00000000: 7628 0200 659c 1bf9 4429 0000 0000 0000  v(..e...D)......
+00000010: ffff ffff ffff ffff ffff ffff ffff ffff  ................
+00000020: 0000 0000 0020 0000 659c 1bf9 1621 659c  ..... ..e....!e.
+00000030: 1bf9 1621 3400 2000 ffff 0100 0000 0000  ...!4. .........
+00000040: 0000 0022 0000 0000 0030 0000 0000 0000  ...".....0......
+00000050: 0082 9400 b040 cac0 c21a c2c2 ca40 0023  .....@.......@.#
+00000060: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+EOF
+
+CMDLINE="-b binfile -X -f /dev/mtdblock2 -l 6 -k 0x28"
+
+cat >$EXPECTED <<EOF
+659C1BF91621
+EOF


### PR DESCRIPTION
This only affects the `binfile` and `atecc508a` methods since those are
the only two that do binary to hex conversions.
