### PR TITLE
Add -b script method to execute a script that will give the boardid

### DIFF
--- a/src/boardid.c
+++ b/src/boardid.c
@@ -97,6 +97,11 @@ static const char *force_aliases[] = {
     NULL,       NULL
 };
 
+static const char *script_aliases[] = {
+    "script", "Run a script to get the ID (Specify script with '-f')",
+    NULL,       NULL
+};
+
 // aliases, read_id, autodetect, trim_left
 static const struct board_id_pair boards[] = {
     { atecc508a_aliases, atecc508a_id, false, false },
@@ -112,6 +117,7 @@ static const struct board_id_pair boards[] = {
     { nerves_key_aliases, nerves_key_id, false, false },
     { rpi_eth0_aliases, rpi_eth0_macaddr_id, false, false },
     { rpi_wlan0_aliases, rpi_wlan0_macaddr_id, false, false },
+    { script_aliases, script_id, false, false},
     { uboot_env_aliases, uboot_env_id, false, true},
     { NULL, NULL, false, false }
 };

--- a/src/common.h
+++ b/src/common.h
@@ -52,6 +52,7 @@ bool macaddr_id(const struct boardid_options *options, char *buffer);
 bool nerves_key_id(const struct boardid_options *options, char *buffer);
 bool rpi_eth0_macaddr_id(const struct boardid_options *options, char *buffer);
 bool rpi_wlan0_macaddr_id(const struct boardid_options *options, char *buffer);
+bool script_id(const struct boardid_options * options, char *buffer);
 bool uboot_env_id(const struct boardid_options *options, char *buffer);
 
 // The root prefix is used for unit testing so that simulated /proc or /sys

--- a/src/script.c
+++ b/src/script.c
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2020 Nerves Project Developers
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common.h"
+
+bool script_id(const struct boardid_options *options, char *buffer)
+{
+    int pipefd[2];
+    if (pipe(pipefd) < 0)
+        return false;
+
+    pid_t pid = fork();
+
+    if (pid == -1) {
+        return false;
+    }
+
+    bool got_sn = false;
+
+    if (pid == 0) {
+        // child
+        int devnull = open("/dev/null", O_RDWR);
+        if (devnull < 0)
+            exit(EXIT_FAILURE);
+
+        close(pipefd[0]);
+        close(STDIN_FILENO);
+        close(STDOUT_FILENO);
+        close(STDERR_FILENO);
+        dup2(devnull, STDIN_FILENO);
+        dup2(pipefd[1], STDOUT_FILENO);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(devnull);
+
+        char* argv[] = {
+            (char*)options->filename,
+            NULL
+        };
+        execvp(argv[0], argv);
+
+        exit(EXIT_FAILURE);
+    } else {
+        //parent
+        close(pipefd[1]);
+
+        int amount_read = 0;
+        int i = 0;
+        int amount_to_read = MAX_SERIALNUMBER_LEN;
+        do {
+            amount_read = read(pipefd[0], &buffer[i], amount_to_read);
+            if (amount_read > 0) {
+                i += amount_read;
+                amount_to_read -= amount_read;
+            }
+        } while(amount_read > 0);
+
+        if (i > 0 && i <= MAX_SERIALNUMBER_LEN) {
+            got_sn = true;
+            buffer[i] = '\0';
+        }
+
+        close(pipefd[0]);
+        int wstatus;
+        do {
+            pid_t w = waitpid(pid, &wstatus, 0);
+            if (w != pid) {
+                got_sn = false;
+                break;
+            }
+
+        } while (!WIFEXITED(wstatus) && !WIFSIGNALED(wstatus));
+
+        if (WEXITSTATUS(wstatus) != 0) {
+            got_sn = false;
+        }
+    }
+
+    return got_sn;
+}


### PR DESCRIPTION
We have a board that needs some custom logic for getting the serial number. This PR adds an option to run a script that is given to get a boardid string to use if available via that method.