### PR TITLE
Prefer the sysfs path for reading device tree serials

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Supported boards/methods:
   chip       Next Thing Co - C.H.I.P.
   cpuinfo    Read /proc/cpuinfo
   jetson     nVidia Jetson
-  device_tree  Read /proc/device-tree/serial-number
+  device_tree Read /sys/firmware/devicetree/base/serial-number
   dmi        Read the system ID out of the SMBIOS/DMI
   force      Force the ID (Specify ID with '-f')
   grisp      GRiSP

--- a/src/boardid.c
+++ b/src/boardid.c
@@ -47,7 +47,7 @@ static const char *rpi_wlan0_aliases[] = {
 
 static const char *device_tree_aliases[] = {
     "jetson",   "nVidia Jetson",
-    "device_tree",  "Read /proc/device-tree/serial-number",
+    "device_tree",  "Read /sys/firmware/devicetree/base/serial-number",
     NULL,       NULL
 };
 

--- a/src/device_tree.c
+++ b/src/device_tree.c
@@ -8,15 +8,17 @@
 
 #include "common.h"
 
-// Read the serial number from /proc/device-tree/serial-number.
-// The nVIDIA Jetson Nano and probably quite a few other devices
-// report their IDs through here.
-
+// Read the serial number from the device tree. Many devices
+// place it here including Raspberry Pi's and nVIDIA Jetson's.
 bool device_tree_id(const struct boardid_options *options, char *buffer)
 {
-    FILE *fp = fopen_helper("/proc/device-tree/serial-number", "r");
-    if (!fp)
-        return false;
+    FILE *fp = fopen_helper("/sys/firmware/devicetree/base/serial-number", "r");
+    if (!fp) {
+        // Try the legacy path
+        fp = fopen_helper("/proc/device-tree/serial-number", "r");
+        if (!fp)
+            return false;
+    }
 
     size_t len = fread(buffer, 1, MAX_SERIALNUMBER_LEN, fp);
     fclose(fp);

--- a/tests/053_device_tree_sysfs
+++ b/tests/053_device_tree_sysfs
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2025 Frank Hunleth
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Prefer reading device tree serial numbers from
+# /sys/firmware/devicetree/base/serial-number.
+#
+# Tests 037 and 038 cover falling back to /proc/device-tree/serial-number.
+#
+
+mkdir -p "$WORK/sys/firmware/devicetree/base"
+cat >"$WORK/sys/firmware/devicetree/base/serial-number" << EOF
+1000000022d28465
+EOF
+
+mkdir -p "$WORK/proc/device-tree"
+cat >"$WORK/proc/device-tree/serial-number" << EOF
+NOT_THE_ID_YOU_WANT
+EOF
+
+CMDLINE="-b device_tree"
+
+cat >"$EXPECTED" <<EOF
+1000000022d28465
+EOF


### PR DESCRIPTION
The /proc/device-tree/serial-number path is a symlink to the sysfs
path, so this really just saves following a symlink. If the sysfs path
somehow doesn't exist, the old /proc location is tried.

This change won't break anything and I bet the /proc location won't be
removed. It looks better to me to try the preferred location first.
